### PR TITLE
Speed up php-cs-fixer by not scanning vendor/

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,9 +1,6 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
-    ->exclude('vendor')
-    ->in(__DIR__)
-;
+$finder = PhpCsFixer\Finder::create()->in(__DIR__ . '/src');
 
 return PhpCsFixer\Config::create()
     ->setRules([


### PR DESCRIPTION
With the exclude/in combination, it seems it would still look for all the files inside vendor/.  This way it's much faster.