### PR TITLE
Add nl translations for label

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "shopware-plugin-class": "WebwinkelKeur\\Shopware\\WebwinkelKeur",
         "plugin-icon": "Resources/config/plugin.png",
         "label": {
-            "en-GB": "WebwinkelKeur"
+            "en-GB": "WebwinkelKeur",
+            "nl-NL": "WebwinkelKeur"
         },
         "description": {
             "en-GB": "Connect your store to WebwinkelKeur.",


### PR DESCRIPTION
https://github.com/webwinkelkeur/shopware/issues/11
Someone has found what's causing the issue with the installation not showing in the installed plugins list.
The  `nl` translation for `label` is missing, which is causing the installation to fail for systems without English.