### PR TITLE
Multi shop configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+
+  shopware:
+    image: dockware/dev:latest
+    container_name: shopware
+    ports:
+      - "17320:80"
+      - "17321:3306"
+      - "17322:22"
+      - "17323:8888"
+      - "17324:9999"
+    volumes:
+      - "db_volume:/var/lib/mysql"
+      - "shop_volume:/var/www/html"
+      - "./:/var/www/html/custom/plugins/webwinkelkeur"
+    environment:
+      - XDEBUG_ENABLED=1
+      - PHP_VERSION=7.4
+
+volumes:
+  db_volume:
+    driver: local
+  shop_volume:
+    driver: local

--- a/src/Events/InvitationLogEvent.php
+++ b/src/Events/InvitationLogEvent.php
@@ -8,10 +8,10 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\BusinessEventInterface;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
-use Shopware\Core\Framework\Log\LogAwareBusinessEventInterface;
+use Shopware\Core\Framework\Log\LogAware;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InvitationLogEvent extends Event implements BusinessEventInterface, LogAwareBusinessEventInterface {
+class InvitationLogEvent extends Event implements BusinessEventInterface, LogAware {
     public const LOG_NAME = 'webwinkelkeur.invitation';
 
     /**

--- a/src/Listener/OrderListener.php
+++ b/src/Listener/OrderListener.php
@@ -19,7 +19,7 @@ class OrderListener {
     /**
      * @var EntityRepository
      */
-    private $orderRepository;
+    private EntityRepository $orderRepository;
 
     public function __construct(
         EntityRepository $order_repository,

--- a/src/Listener/OrderListener.php
+++ b/src/Listener/OrderListener.php
@@ -6,7 +6,7 @@ use Shopware\Core\Checkout\Cart\Exception\OrderNotFoundException;
 use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use WebwinkelKeur\Shopware\Service\InvitationService;
 
@@ -14,25 +14,25 @@ class OrderListener {
     /**
      * @var InvitationService
      */
-    private $invitation_service;
+    private InvitationService $invitationService;
 
     /**
-     * @var EntityRepositoryInterface
+     * @var EntityRepository
      */
-    private $order_repository;
+    private $orderRepository;
 
     public function __construct(
-        EntityRepositoryInterface $order_repository,
+        EntityRepository $order_repository,
         InvitationService $invitation_service
     ) {
-        $this->order_repository = $order_repository;
-        $this->invitation_service = $invitation_service;
+        $this->orderRepository = $order_repository;
+        $this->invitationService = $invitation_service;
     }
 
     public function onOrderCompleted(OrderStateMachineStateChangeEvent $event): void {
         $context = $event->getContext();
         $order = $this->getOrder($event->getOrder()->getUniqueIdentifier(), $context);
-        $this->invitation_service->sendInvitation($order, $context);
+        $this->invitationService->sendInvitation($order, $context);
     }
 
     /**
@@ -41,7 +41,7 @@ class OrderListener {
     private function getOrder(string $order_id, Context $context): OrderEntity {
         $order_criteria = $this->getOrderCriteria($order_id);
         /** @var OrderEntity|null $order */
-        $order = $this->order_repository->search($order_criteria, $context)->first();
+        $order = $this->orderRepository->search($order_criteria, $context)->first();
         if ($order === null) {
             throw new OrderNotFoundException($order_id);
         }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <!-- services -->
         <service id="WebwinkelKeur\Shopware\Service\InvitationService">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="Shopware\Core\Framework\Event\BusinessEventDispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Flow\Dispatching\FlowDispatcher"/>
         </service>
         <!-- subscribes -->
         <service id="WebwinkelKeur\Shopware\Subscriber\StorefrontRenderSubscriber">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <!-- services -->
         <service id="WebwinkelKeur\Shopware\Service\InvitationService">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="Shopware\Core\Content\Flow\Dispatching\FlowDispatcher"/>
+            <argument type="service" id="Shopware\Core\Framework\Event\BusinessEventDispatcher"/>
         </service>
         <!-- subscribes -->
         <service id="WebwinkelKeur\Shopware\Subscriber\StorefrontRenderSubscriber">

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -4,7 +4,20 @@
     {{ parent() }}
     {% if webwinkelkeur_javascript %}
         {% block webwinkelkeur_sidebar_script %}
-            <script>(function(url,id){var script=document.createElement('script');script.async=true;script.src=url+'/sidebar.js?id='+id+'&c='+cachebuster(10,id);var ref=document.getElementsByTagName('script')[0];ref.parentNode.insertBefore(script,ref);function cachebuster(refreshMinutes,id){var now=Date.now();var interval=refreshMinutes*60e3;var shift=(Math.sin(id)||0)*interval;return Math.floor((now+shift)/interval);}})('https://dashboard.webwinkelkeur.nl',{{ _webwinkelkeur_id }});</script>
+            <script>(function (url, id) {
+                    const script = document.createElement('script');
+                    script.async = true;
+                    script.src = url + '/sidebar.js?id=' + id + '&c=' + cachebuster(10, id);
+                    const ref = document.getElementsByTagName('script')[0];
+                    ref.parentNode.insertBefore(script, ref);
+
+                    function cachebuster(refreshMinutes, id) {
+                        const now = Date.now();
+                        const interval = refreshMinutes * 60e3;
+                        const shift = (Math.sin(id) || 0) * interval;
+                        return Math.floor((now + shift) / interval);
+                    }
+                })('https://dashboard.webwinkelkeur.nl',{{ _webwinkelkeur_id }});</script>
         {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Service/InvitationService.php
+++ b/src/Service/InvitationService.php
@@ -14,7 +14,7 @@ class InvitationService {
      */
     private SystemConfigService $systemConfigService;
 
-    private $dispatcher;
+    private FlowDispatcher $dispatcher;
 
     const INVITATION_URL = 'https://dashboard.webwinkelkeur.nl/api/1.0/invitations.json';
 
@@ -22,7 +22,7 @@ class InvitationService {
 
     const LOG_FAILED = 'Sending invitation has failed';
 
-    private $context;
+    private Context $context;
 
     private string $salesChannelId;
 
@@ -34,7 +34,7 @@ class InvitationService {
         $this->dispatcher = $flow_dispatcher;
     }
 
-    public function sendInvitation(OrderEntity $order, Context $context) {
+    public function sendInvitation(OrderEntity $order, Context $context): void {
         $this->context = $context;
         $this->salesChannelId = $context->getSource()->getSalesChannelId();
 
@@ -43,8 +43,9 @@ class InvitationService {
             empty($this->systemConfigService->get('WebwinkelKeur.config.webshopId', $this->salesChannelId))
         ) {
             $this->logErrorMessage('Empty API credentials');
-            return [];
+            return;
         }
+
         if (empty($this->systemConfigService->get('WebwinkelKeur.config.enableInvitations', $this->salesChannelId))) {
             return;
         }

--- a/src/Service/InvitationService.php
+++ b/src/Service/InvitationService.php
@@ -3,8 +3,8 @@
 namespace WebwinkelKeur\Shopware\Service;
 
 use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Content\Flow\Dispatching\FlowDispatcher;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventDispatcher;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use WebwinkelKeur\Shopware\Events\InvitationLogEvent;
 
@@ -14,7 +14,7 @@ class InvitationService {
      */
     private SystemConfigService $systemConfigService;
 
-    private FlowDispatcher $dispatcher;
+    private BusinessEventDispatcher $dispatcher;
 
     const INVITATION_URL = 'https://dashboard.webwinkelkeur.nl/api/1.0/invitations.json';
 
@@ -28,10 +28,10 @@ class InvitationService {
 
     public function __construct(
         SystemConfigService $system_config_service,
-        FlowDispatcher $flow_dispatcher
+        BusinessEventDispatcher $dispatcher
     ) {
         $this->systemConfigService = $system_config_service;
-        $this->dispatcher = $flow_dispatcher;
+        $this->dispatcher = $dispatcher;
     }
 
     public function sendInvitation(OrderEntity $order, Context $context): void {

--- a/src/Subscriber/StorefrontRenderSubscriber.php
+++ b/src/Subscriber/StorefrontRenderSubscriber.php
@@ -10,10 +10,10 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface {
     /**
      * @var SystemConfigService
      */
-    private $system_config_service;
+    private SystemConfigService $systemConfigService;
 
     public function __construct(SystemConfigService $system_config_service) {
-        $this->system_config_service = $system_config_service;
+        $this->systemConfigService = $system_config_service;
     }
 
     public static function getSubscribedEvents(): array {
@@ -23,8 +23,9 @@ class StorefrontRenderSubscriber implements EventSubscriberInterface {
     }
 
     public function onRender(StorefrontRenderEvent $event): void {
-        $webshop_id= $this->system_config_service->get('WebwinkelKeur.config.webshopId');
-        $webwinkelkeur_javascript = $this->system_config_service->get('WebwinkelKeur.config.webwinkelKeurJavascript');
+        $sales_channel_id = $event->getContext()->getSource()->getSalesChannelId();
+        $webshop_id = $this->systemConfigService->get('WebwinkelKeur.config.webshopId', $sales_channel_id);
+        $webwinkelkeur_javascript = $this->systemConfigService->get('WebwinkelKeur.config.webwinkelKeurJavascript', $sales_channel_id);
         if (empty($webshop_id)) {
             $webwinkelkeur_javascript = false;
         }


### PR DESCRIPTION
Imagine you have multiple shops, now image you want different configs for each- it does not work.
<img width="990" alt="Screenshot 2022-07-15 at 16 24 50" src="https://user-images.githubusercontent.com/14910608/179232059-94a400bd-3de7-4304-9d11-8dcd1e959137.png">

Pass `salesChannelId` to [SystemConfigService::get](https://github.com/shopware/platform/blob/cd5cd37427d42674c58a22351f39d96429d3f337/src/Core/System/SystemConfig/SystemConfigService.php#L68), the webshop owner will still be able to use the common(shared) configs with the inheritance option.
<img width="543" alt="Screenshot 2022-07-15 at 16 27 32" src="https://user-images.githubusercontent.com/14910608/179232540-6e2536a5-3c6d-4f33-b708-2912630f404d.png">

More in this PR:
* add docker-compose.yml
* Minor code improvements
* Fix some deprecated usages


[sc-19964]