### PR TITLE
Fix InvitationService

### DIFF
--- a/src/Listener/OrderListener.php
+++ b/src/Listener/OrderListener.php
@@ -30,9 +30,8 @@ class OrderListener {
     }
 
     public function onOrderCompleted(OrderStateMachineStateChangeEvent $event): void {
-        $context = $event->getContext();
-        $order = $this->getOrder($event->getOrder()->getUniqueIdentifier(), $context);
-        $this->invitationService->sendInvitation($order, $context);
+        $order = $this->getOrder($event->getOrder()->getUniqueIdentifier(), $event->getContext());
+        $this->invitationService->sendInvitation($order, $event);
     }
 
     /**

--- a/src/Service/InvitationService.php
+++ b/src/Service/InvitationService.php
@@ -2,8 +2,8 @@
 
 namespace WebwinkelKeur\Shopware\Service;
 
+use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
 use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\BusinessEventDispatcher;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use WebwinkelKeur\Shopware\Events\InvitationLogEvent;
@@ -22,7 +22,7 @@ class InvitationService {
 
     const LOG_FAILED = 'Sending invitation has failed';
 
-    private Context $context;
+    private OrderStateMachineStateChangeEvent $orderStateMachineStateChangeEvent;
 
     public function __construct(
         SystemConfigService $system_config_service,
@@ -32,8 +32,8 @@ class InvitationService {
         $this->dispatcher = $dispatcher;
     }
 
-    public function sendInvitation(OrderEntity $order, Context $context): void {
-        $this->context = $context;
+    public function sendInvitation(OrderEntity $order, OrderStateMachineStateChangeEvent $orderStateMachineStateChangeEvent): void {
+        $this->orderStateMachineStateChangeEvent = $orderStateMachineStateChangeEvent;
 
         if (
             empty($this->getConfigValue('apiKey')) ||
@@ -124,7 +124,7 @@ class InvitationService {
             $subject,
             $status,
             $info,
-            $this->context
+            $this->orderStateMachineStateChangeEvent->getContext()
         );
         $this->dispatcher->dispatch($invitation_log_event);
     }
@@ -136,7 +136,7 @@ class InvitationService {
     private function getConfigValue(string $name) {
         return $this->systemConfigService->get(
             "WebwinkelKeur.config.{$name}",
-            $this->context->getSource()->getSalesChannelId()
+            $this->orderStateMachineStateChangeEvent->getSalesChannelId()
         );
     }
 }


### PR DESCRIPTION
`Attempted to call an undefined method named "getSalesChannelId" of class "Shopware\Core\Framework\Api\Context\AdminApiSource"`

Get the salesChannelID from `OrderStateMachineStateChangeEvent`